### PR TITLE
Add locale option for supporting localized month and day names

### DIFF
--- a/CalendarPicker.js
+++ b/CalendarPicker.js
@@ -55,32 +55,10 @@ function CalendarPicker(element, options) {
     this.calendarGrid = document.createElement('section');
     this.calendarDayElementType = 'time';
 
-    // Hard-coded list of all days.
-    this.listOfAllDaysAsText = [
-        'Monday',
-        'Tuesday',
-        'Wednesday',
-        'Thursday',
-        'Friday',
-        'Saturday',
-        'Sunday'
-    ];
-
-    // Hard-coded list of all months.
-    this.listOfAllMonthsAsText = [
-        'January',
-        'February',
-        'March',
-        'April',
-        'May',
-        'June',
-        'July',
-        'August',
-        'September',
-        'October',
-        'November',
-        'December'
-    ];
+    var beginningOfYearOnMonday = new Date('2018-01-01');
+    var locale = options.locale || 'en-US';
+    this.listOfAllDaysAsText = [...Array(7).keys()].map(this._toTranslatedWeekday(beginningOfYearOnMonday, locale))
+    this.listOfAllMonthsAsText = [...Array(12).keys()].map(this._toTranslatedMonth(beginningOfYearOnMonday, locale))
 
     // Creating the calendar
     this.calendarWrapper.id = 'calendar-wrapper';
@@ -100,6 +78,19 @@ function CalendarPicker(element, options) {
     this.userElement.appendChild(this.calendarWrapper);
 }
 
+CalendarPicker.prototype._toTranslatedWeekday = function(beginningOfYearOnMonday, locale) {
+    return function(dayOfWeekIndex) {
+        return new Intl.DateTimeFormat(locale, { weekday: 'long'})
+            .format(new Date(beginningOfYearOnMonday.getFullYear(), beginningOfYearOnMonday.getMonth(), beginningOfYearOnMonday.getDate() + dayOfWeekIndex))
+    }
+}
+
+CalendarPicker.prototype._toTranslatedMonth = function(beginningOfYearOnMonday, locale) {
+    return function(monthIndex) {
+        return new Intl.DateTimeFormat(locale, { month: 'long'})
+            .format(new Date(beginningOfYearOnMonday.getFullYear(), beginningOfYearOnMonday.getMonth() + monthIndex, beginningOfYearOnMonday.getDate()))
+    }
+}
 
 /**
  * @param {Number} The month number, 0 based.

--- a/CalendarPicker.js
+++ b/CalendarPicker.js
@@ -57,7 +57,7 @@ function CalendarPicker(element, options) {
 
     var beginningOfYearOnMonday = new Date('2018-01-01');
     var locale = options.locale || 'en-US';
-    this.listOfAllDaysAsText = [...Array(7).keys()].map(this._toTranslatedWeekday(beginningOfYearOnMonday, locale))
+    this.listOfAllDaysAsText = [...Array(7).keys()].map(this._toTranslatedWeekday(beginningOfYearOnMonday, locale, options.showShortWeekdays))
     this.listOfAllMonthsAsText = [...Array(12).keys()].map(this._toTranslatedMonth(beginningOfYearOnMonday, locale))
 
     // Creating the calendar
@@ -78,16 +78,17 @@ function CalendarPicker(element, options) {
     this.userElement.appendChild(this.calendarWrapper);
 }
 
-CalendarPicker.prototype._toTranslatedWeekday = function(beginningOfYearOnMonday, locale) {
+CalendarPicker.prototype._toTranslatedWeekday = function(beginningOfYearOnMonday, locale, showShortWeekdays) {
+    var weekdayFormat = showShortWeekdays ? 'short' : 'long'
     return function(dayOfWeekIndex) {
-        return new Intl.DateTimeFormat(locale, { weekday: 'long'})
+        return new Intl.DateTimeFormat(locale, { weekday: weekdayFormat })
             .format(new Date(beginningOfYearOnMonday.getFullYear(), beginningOfYearOnMonday.getMonth(), beginningOfYearOnMonday.getDate() + dayOfWeekIndex))
     }
 }
 
 CalendarPicker.prototype._toTranslatedMonth = function(beginningOfYearOnMonday, locale) {
     return function(monthIndex) {
-        return new Intl.DateTimeFormat(locale, { month: 'long'})
+        return new Intl.DateTimeFormat(locale, { month: 'long' })
             .format(new Date(beginningOfYearOnMonday.getFullYear(), beginningOfYearOnMonday.getMonth() + monthIndex, beginningOfYearOnMonday.getDate()))
     }
 }

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 The simple and pretty way to let a user select a day!
 - Supports all major browser.
 - Entirely written in Vanilla JavaScript with no dependencies.
-- Has a reactive "onValueChange" callback that can be used to everytime the date changes.
+- Has a reactive "onValueChange" callback that can be used everytime the date changes.
 
 [Live demo](https://mathiaspicker.com/CalendarPickerJS)
 

--- a/example.html
+++ b/example.html
@@ -163,7 +163,7 @@
         <pre>   min: new Date(),</pre>
         <pre>   max: new Date(nextYear, 10), // NOTE: new Date(nextYear, 10) is "Nov 01 nextYear"</pre>
         <pre>   locale: 'en-US', // Can be any locale or language code supported by Intl.DateTimeFormat, defaults to 'en-US'</pre>
-        <pre>   showShortWeekDays: false // Can be used to fit calendar onto smaller (mobile) screens, defaults to false</pre>
+        <pre>   showShortWeekdays: false // Can be used to fit calendar onto smaller (mobile) screens, defaults to false</pre>
         <pre>});</pre>
         <pre> </pre>
         <pre>const currentDateElement = document.getElementById('current-date');</pre>
@@ -201,7 +201,7 @@
         min: new Date(),
         max: new Date(nextYear, 10), // NOTE: new Date(nextYear, 10) is "Nov 01 <nextYear>"
         locale: 'en-US', // Can be any locale or language code supported by Intl.DateTimeFormat, defaults to 'en-US'
-        showShortWeekDays: false // Can be used to fit calendar onto smaller (mobile) screens, defaults to false
+        showShortWeekdays: false // Can be used to fit calendar onto smaller (mobile) screens, defaults to false
     });
 
     const currentDateElement = document.getElementById('current-date');

--- a/example.html
+++ b/example.html
@@ -162,7 +162,8 @@
         <pre>   // If max < min or min > max then the only available day will be today.</pre>
         <pre>   min: new Date(),</pre>
         <pre>   max: new Date(nextYear, 10), // NOTE: new Date(nextYear, 10) is "Nov 01 nextYear"</pre>
-        <pre>   locale: 'en-US' // Can be any locale or language code supported by Intl.DateTimeFormat, defaults to 'en-US'</pre>
+        <pre>   locale: 'en-US', // Can be any locale or language code supported by Intl.DateTimeFormat, defaults to 'en-US'</pre>
+        <pre>   showShortWeekDays: false // Can be used to fit calendar onto smaller (mobile) screens, defaults to false</pre>
         <pre>});</pre>
         <pre> </pre>
         <pre>const currentDateElement = document.getElementById('current-date');</pre>
@@ -199,7 +200,8 @@
         // If max < min or min > max then the only available day will be today.
         min: new Date(),
         max: new Date(nextYear, 10), // NOTE: new Date(nextYear, 10) is "Nov 01 <nextYear>"
-        locale: 'en-US' // Can be any locale or language code supported by Intl.DateTimeFormat, defaults to 'en-US'
+        locale: 'en-US', // Can be any locale or language code supported by Intl.DateTimeFormat, defaults to 'en-US'
+        showShortWeekDays: false // Can be used to fit calendar onto smaller (mobile) screens, defaults to false
     });
 
     const currentDateElement = document.getElementById('current-date');

--- a/example.html
+++ b/example.html
@@ -161,7 +161,8 @@
         <pre>const myCalender = new CalendarPicker('<span class="pink">#myCalendarWrapper</span>', {</pre>
         <pre>   // If max < min or min > max then the only available day will be today.</pre>
         <pre>   min: new Date(),</pre>
-        <pre>   max: new Date(nextYear, 10) // NOTE: new Date(nextYear, 10) is "Sun Nov 01 nextYear"</pre>
+        <pre>   max: new Date(nextYear, 10), // NOTE: new Date(nextYear, 10) is "Nov 01 nextYear"</pre>
+        <pre>   locale: 'en-US' // Can be any locale or language code supported by Intl.DateTimeFormat, defaults to 'en-US'</pre>
         <pre>});</pre>
         <pre> </pre>
         <pre>const currentDateElement = document.getElementById('current-date');</pre>
@@ -197,7 +198,8 @@
     const myCalender = new CalendarPicker('#myCalendarWrapper', {
         // If max < min or min > max then the only available day will be today.
         min: new Date(),
-        max: new Date(nextYear, 10) // NOTE: new Date(nextYear, 10) is "Sun Nov 01 <nextYear>"
+        max: new Date(nextYear, 10), // NOTE: new Date(nextYear, 10) is "Nov 01 <nextYear>"
+        locale: 'en-US' // Can be any locale or language code supported by Intl.DateTimeFormat, defaults to 'en-US'
     });
 
     const currentDateElement = document.getElementById('current-date');


### PR DESCRIPTION
It addresses PR #3 by using `Intl.DateTimeFormat#format` for getting month and day names.